### PR TITLE
Makes installable by 3.0 and beyond

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,6 @@
     "description": "Adds support for quickly adding a snow day banner at the top of a website.",
     "require": {
         "composer/installers": "~1.0",
-        "october/system": "^2.0"
+        "october/system": ">=2.0"
     }
 }


### PR DESCRIPTION
Hey Joe,

Constraints like `^2.0` and `~2.0` will block support with newer major versions, such as October v3.

Alternatively, it could be more explicit:

```
"october/system": "^2.0|^3.0"
```

But, this plugin looks simple enough that it will remain compatible with all future versions so `>=2.0` seems like the better option. [Docs have been updated with this guidance](https://github.com/octobercms/docs/commit/472f3cbc83b3dfa6af82814173b4b1caab04a0bd).